### PR TITLE
Adding well-named coverage for local symbol table import maxId cases

### DIFF
--- a/iontestdata/good/localSymbolTableImportNegativeMaxId.ion
+++ b/iontestdata/good/localSymbolTableImportNegativeMaxId.ion
@@ -1,0 +1,9 @@
+$ion_1_0
+$ion_symbol_table::
+{
+  imports:[ { name: "fred",
+              version: 1,
+              max_id: -1 },
+  ],
+}
+a

--- a/iontestdata/good/localSymbolTableImportNonIntegerMaxId.ion
+++ b/iontestdata/good/localSymbolTableImportNonIntegerMaxId.ion
@@ -1,11 +1,9 @@
 $ion_1_0
-
-// Import declaration with zero max_id
 $ion_symbol_table::
 {
   imports:[ { name: "fred",
               version: 1,
-              max_id: 0 },
+              max_id: "1" },
   ],
 }
 a

--- a/iontestdata/good/localSymbolTableImportNullMaxId.ion
+++ b/iontestdata/good/localSymbolTableImportNullMaxId.ion
@@ -1,0 +1,9 @@
+$ion_1_0
+$ion_symbol_table::
+{
+  imports:[ { name: "fred",
+              version: 1,
+              max_id: null.int },
+  ],
+}
+a

--- a/iontestdata/good/localSymbolTableImportZeroMaxId.ion
+++ b/iontestdata/good/localSymbolTableImportZeroMaxId.ion
@@ -1,0 +1,9 @@
+$ion_1_0
+$ion_symbol_table::
+{
+  imports:[ { name: "fred",
+              version: 1,
+              max_id: 0 },
+  ],
+}
+a


### PR DESCRIPTION
Per the spec:

"If a max_id field is defined but is null, not an int, or less than zero, act as if it is undefined."