### PR TITLE
Moving local symbol table import test data with improper max_id to ba…

### DIFF
--- a/iontestdata/bad/localSymbolTableImportNegativeMaxId.ion
+++ b/iontestdata/bad/localSymbolTableImportNegativeMaxId.ion
@@ -1,3 +1,4 @@
+// Fails because there is no symbol table named "fred" and the max_id is effectively undefined (less than zero)
 $ion_1_0
 $ion_symbol_table::
 {

--- a/iontestdata/bad/localSymbolTableImportNonIntegerMaxId.ion
+++ b/iontestdata/bad/localSymbolTableImportNonIntegerMaxId.ion
@@ -1,3 +1,4 @@
+// Fails because there is no symbol table named "fred" and the max_id is effectively undefined (not an integer)
 $ion_1_0
 $ion_symbol_table::
 {

--- a/iontestdata/bad/localSymbolTableImportNullMaxId.ion
+++ b/iontestdata/bad/localSymbolTableImportNullMaxId.ion
@@ -1,3 +1,4 @@
+// Fails because there is no symbol table named "fred" and the max_id is effectively undefined (null)
 $ion_1_0
 $ion_symbol_table::
 {


### PR DESCRIPTION
…d test data

From the spec:

Import structs in an import list are processed in order as follows:

1. If no name field is defined, or if it is not a non-empty string, the import clause is ignored.
2. If the name field is "$ion", the import clause is ignored.
3. If no version field is defined, or if it is null, not an int, or less than 1, act as if it is 1.
4. If a max_id field is defined but is null, not an int, or less than zero, act as if it is undefined.
5. Select a shared symbol table instance as follows:
  1. Query the catalog to retrieve the specified table by name and version.
  2. If an exact match is not found:
    1. If max_id is undefined, implementations MUST raise an error and halt processing.

These test cases satisfy the case where the max_id is undefined and no exact match is found in the catalog (since the shared symbol table "fred" isn't defined)