### PR TITLE
Splits a nonequivs symbol table file into two; slightly modifies...

### DIFF
--- a/iontestdata/good/equivs/systemSymbols.ion
+++ b/iontestdata/good/equivs/systemSymbols.ion
@@ -4,8 +4,10 @@
   $ion
 )
 (
-  $2
-  $ion_1_0
+  // When roundtripped as top-level values, these are no longer equivalent, as $ion_1_0 is an IVM while $2 is not.
+  // Putting these in containers solves that problem; there are no IVMs below the top level.
+  ($2)
+  ($ion_1_0)
 )
 (
   $3

--- a/iontestdata/good/non-equivs/symbolTablesUnknownText.ion
+++ b/iontestdata/good/non-equivs/symbolTablesUnknownText.ion
@@ -1,9 +1,9 @@
-// different declared local symbols
+// import declaration, with max_id > 0
 embedded_documents::[
     '''
     $ion_1_0
     $ion_symbol_table::{
-        symbols:[ "rock", "paper", "scissors" ]
+        symbols:[ "foo", "bar", "baz" ]
     }
     $10
     $11
@@ -12,6 +12,10 @@ embedded_documents::[
     '''
     $ion_1_0
     $ion_symbol_table::{
+        imports:[ { name: "com.amazon.ion.tests",
+                    version: 1,
+                    max_id: 1 }
+        ],
         symbols:[ "foo", "bar", "baz" ]
     }
     $10


### PR DESCRIPTION
…an equivs file containing IVMs so that it will correctly roundtrip under the new IVM semantics.

The new `symbolTablesUnknownText.ion` file isolates the case where there is a symbol with unknown text due to an unavailable import. Implementations that don't yet support roundtripping in this scenario should not have to skip the other vector in the `symbolTables.ion` file, which is much more typical.